### PR TITLE
validation webhook to accept 'replication-factor' greater than 0…

### DIFF
--- a/api/v1alpha1/kafkatopic_webhook.go
+++ b/api/v1alpha1/kafkatopic_webhook.go
@@ -109,7 +109,7 @@ func (r *KafkaTopic) validateKafkaTopicName() *field.Error {
 func (r *KafkaTopic) validateKafkaTopicSpec() *field.Error {
 	spec := field.NewPath("spec")
 	if !r.replicationFactorOkay() {
-		return field.Invalid(spec.Child("replicationFactor"), "replication-factor", "must be greater than 3")
+		return field.Invalid(spec.Child("replicationFactor"), "replication-factor", "must be greater than 0")
 	}
 	if !r.partitionsOkay() {
 		return field.Invalid(spec.Child("partitions"), "partitions", "must be greater than 0")
@@ -124,7 +124,7 @@ func (r *KafkaTopic) validateKafkaTopicSpec() *field.Error {
 }
 
 func (r *KafkaTopic) replicationFactorOkay() bool {
-	if r.Spec.ReplicationFactor >= 3 {
+	if r.Spec.ReplicationFactor > 0 {
 		return true
 	}
 	return false


### PR DESCRIPTION
… instead of 3

Hello,
currently the webhook validation controller denies creation acceptance of KakfaTopic if `replication-factor` is less than 3
```
admission webhook "vkafkatopic.kb.io" denied the request: kafkatopic.kafka.btrace.com "dev-topic" is invalid: spec.replicationFactor: Invalid value: "replication-factor": must be greater than 3
```
Hence, Updated the validation webhook to accept KafkaTopic if below is provided
```
...
spec:
  replication-factor: 1
...
...
```

 During development and testing on a local machine or in any test environment, we do not usually require minimum Replication Factor `3` and also in cases where we do not run kafka in distributed mode.